### PR TITLE
Enumerating devices , select first and white balance prop

### DIFF
--- a/src/gsttoupcamsrc.c
+++ b/src/gsttoupcamsrc.c
@@ -77,6 +77,10 @@ enum
     PROP_BB_R,
     PROP_BB_G,
     PROP_BB_B,
+
+    PROP_WB_R,
+    PROP_WB_G,
+    PROP_WB_B,    
 };
 
 
@@ -212,6 +216,17 @@ gst_toupcam_src_class_init (GstToupCamSrcClass * klass)
     g_object_class_install_property (gobject_class, PROP_BB_B,
             g_param_spec_int ("bb_b", "...", "...",
                     0, 255, 0, G_PARAM_READABLE | G_PARAM_WRITABLE));
+
+
+    g_object_class_install_property (gobject_class, PROP_WB_R,
+            g_param_spec_int ("wb_r", "...", "...",
+                    0, 255, 0, G_PARAM_READABLE | G_PARAM_WRITABLE));
+    g_object_class_install_property (gobject_class, PROP_WB_G,
+            g_param_spec_int ("wb_g", "...", "...",
+                    0, 255, 0, G_PARAM_READABLE | G_PARAM_WRITABLE));
+    g_object_class_install_property (gobject_class, PROP_WB_B,
+            g_param_spec_int ("wb_b", "...", "...",
+                    0, 255, 0, G_PARAM_READABLE | G_PARAM_WRITABLE));
 }
 
 static void
@@ -231,6 +246,11 @@ gst_toupcam_src_init (GstToupCamSrc * src)
     src->black_balance[0] = 0;
     src->black_balance[1] = 0;
     src->black_balance[2] = 0;
+
+    src->white_balance[0] = 0;
+    src->white_balance[1] = 0;
+    src->white_balance[2] = 0;
+
 
     /* set source as live (no preroll) */
     gst_base_src_set_live (GST_BASE_SRC (src), TRUE);
@@ -346,6 +366,24 @@ gst_toupcam_src_set_property (GObject * object, guint property_id,
         }
         break;
 
+    case PROP_WB_R:
+        src->white_balance[0] = g_value_get_int (value);
+        if (src->hCam) {
+            Toupcam_put_WhiteBalanceGain(src->hCam, src->white_balance);
+        }
+        break;
+    case PROP_WB_G:
+        src->white_balance[1] = g_value_get_int (value);
+        if (src->hCam) {
+            Toupcam_put_WhiteBalanceGain(src->hCam, src->white_balance);
+        }
+        break;
+    case PROP_WB_B:
+        src->white_balance[2] = g_value_get_int (value);
+        if (src->hCam) {
+            Toupcam_put_WhiteBalanceGain(src->hCam, src->white_balance);
+        }
+        break;
 
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -433,6 +471,16 @@ gst_toupcam_src_get_property (GObject * object, guint property_id,
         break;
     case PROP_BB_B:
         g_value_set_int (value, src->black_balance[2]);
+        break;
+
+    case PROP_WB_R:
+        g_value_set_int (value, src->white_balance[0]);
+        break;
+    case PROP_WB_G:
+        g_value_set_int (value, src->white_balance[1]);
+        break;
+    case PROP_WB_B:
+        g_value_set_int (value, src->white_balance[2]);
         break;
 
     default:

--- a/src/gsttoupcamsrc.c
+++ b/src/gsttoupcamsrc.c
@@ -582,6 +582,11 @@ static void my_tt_cb(const int nTemp, const int nTint, void* pCtx) {
 static gboolean
 gst_toupcam_src_start (GstBaseSrc * bsrc)
 {
+
+    ToupcamInstV2 arr[TOUPCAM_MAX];
+    unsigned cnt = 0;
+    char  at_id[65];
+
     // Start will open the device but not start it, set_caps starts it, stop should stop and close it (as v4l2src)
 
     GstToupCamSrc *src = GST_TOUPCAM_SRC (bsrc);
@@ -594,15 +599,21 @@ gst_toupcam_src_start (GstBaseSrc * bsrc)
     // read libversion (for informational purposes only)
     GST_INFO_OBJECT (src, "ToupCam Library Ver %s", Toupcam_Version());
 
-    // open first usable device
-    GST_DEBUG_OBJECT (src, "Toupcam_Open");
-    src->hCam = Toupcam_Open(NULL);
-    if (NULL == src->hCam)
-    {
-        GST_ERROR_OBJECT(src, "No ToupCam device found or open failed");
-        goto fail;
-    }
+    // enumerate devices (needed to get device id in order to prepend with "@" to enable RGB gain functions)
+    cnt = Toupcam_EnumV2(arr);
+    for (unsigned i = 0; i < cnt; ++i){
 
+        snprintf(at_id, 65, "@%s", arr[0].id); 
+
+        // open first usable device id preprended with "@"
+        GST_DEBUG_OBJECT (src, "Toupcam_Open");
+        src->hCam = Toupcam_Open(at_id);
+        if (NULL == src->hCam)
+        {
+            GST_ERROR_OBJECT(src, "No ToupCam device found or open failed");
+            goto fail;
+        }
+    }
     //gst_toupcam_pdebug(src);
 
     HRESULT hr;

--- a/src/gsttoupcamsrc.h
+++ b/src/gsttoupcamsrc.h
@@ -62,6 +62,7 @@ struct _GstToupCamSrc
     int contrast;
     int gamma;
     unsigned short black_balance[3];
+    int white_balance[3];
 
     // stream
     gboolean acq_started;


### PR DESCRIPTION
First , enumerate the devices.
If any devices detected, select first , prepend id with "@" in order to enable whitebalance rgb functions.

Added white balance RGB properties . Tested with remote gui from pyuscope/util/gst_prop_gui.py

