### PR TITLE
Modifications to match changes in toupcam SDK

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,8 @@ Install
     cd ~
     # get sdk from here: http://www.touptek.com/download/showdownload.php?lang=en&id=32
     # md5sum
-    # c151ed88b3065569dc344a4a22d90bc3  toupcamsdk.zip
+    # 8e00f2ef863c0a8b560221a23f14cbbb  toupcamsdk.zip
+    # Version: 48.18081.2020.1205 (Found in toupcamsdk/doc/en.html)
     mkdir toupcamsdk
     cd toupcamsdk
     unzip ../toupcamsdk.zip

--- a/src/gsttoupcamsrc.c
+++ b/src/gsttoupcamsrc.c
@@ -424,7 +424,7 @@ gst_toupcam_src_set_property (GObject * object, guint property_id,
     case PROP_AWB_TT:
         if (!(src->awb_rgb || src->awb_tt)) {
             //ok
-            if (FAILED(Toupcam_AwbOnePush(src->hCam, my_tt_cb, src))) {
+            if (FAILED(Toupcam_AwbOnce(src->hCam, my_tt_cb, src))) {
                 GST_ERROR_OBJECT (src, "failed to awb tt");
                 src->awb_tt = 0;
             } else {
@@ -697,7 +697,7 @@ static gboolean
 gst_toupcam_src_start (GstBaseSrc * bsrc)
 {
 
-    ToupcamInstV2 arr[TOUPCAM_MAX];
+    ToupcamDeviceV2 arr[TOUPCAM_MAX];
     unsigned cnt = 0;
     char  at_id[65];
 


### PR DESCRIPTION
As touptek updated their SDK, this code needed to be updated as well. No functional change; just two resource names.

The SDK was fetched May 5, 2021. So these changes will match this version of the toupcam SDK.